### PR TITLE
Alcune piccole modifiche

### DIFF
--- a/1-js/01-getting-started/1-intro/article.md
+++ b/1-js/01-getting-started/1-intro/article.md
@@ -10,17 +10,17 @@ I programmi che sfruttano questo linguaggio vengono chiamati *script*. Possono e
 
 Gli script vengono scritti ed eseguiti come testo semplice. Per questo non richiedono alcuna fase di preparazione o compilazione per essere eseguiti.
 
-In questo aspetto, JavaScript è molto differente da un altro linguaggio chiamato [Java](https://en.wikipedia.org/wiki/Java_(programming_language)).
+Sotto questo aspetto, JavaScript è molto differente da un altro linguaggio chiamato [Java](https://en.wikipedia.org/wiki/Java_(programming_language)).
 
 ```smart header="Perché si chiama <u>Java</u>Script?"
-In origine JavaScript aveva un altro nome: "LiveScript". In quel periodo Java era molto popolare, per questo si è pensato che identificare questo linguaggio come il "fratello minore" di Java potesse aiutare nella sua diffusione.
+In origine JavaScript aveva un altro nome: "LiveScript". In quel periodo Java era molto popolare, per questo si è pensato che identificare Javascript come il "fratello minore" di Java potesse aiutare alla sua diffusione.
 
-Evolvendosi, JavaScript è diventato un linguaggio completamente indipendente, con delle specifiche personali chiamate [ECMAScript](http://en.wikipedia.org/wiki/ECMAScript), e adesso non ha quasi nulla in comune con Java.
+Evolvendosi, JavaScript è diventato un linguaggio completamente indipendente, con una specifica personale chiamata [ECMAScript](http://en.wikipedia.org/wiki/ECMAScript), e adesso non ha quasi nulla in comune con Java.
 ```
 
 Attualmente, JavaScript può essere eseguito non solo nei browser, ma anche nei server web e in altri ambienti che supportano il [motore JavaScript](https://en.wikipedia.org/wiki/JavaScript_engine) (JavaScript engine).
 
-Il browser ha un suo motore JavaScript integrato, chiamato "JavaScript Virtual Machine".
+Il browser ha un suo motore JavaScript integrato, chiamato alle volte "JavaScript Virtual Machine".
 
 Esistono altri motori JavaScript, tra cui:
 
@@ -36,8 +36,8 @@ Il funzionamento di questi motori è complicato, ma i concetti alla base sono se
 
 
 1. I motori (integrati nei browser) leggono ("analizzano") lo script.
-2. Successivamente convertono ("compilano") lo script in linguaggio macchina.
-3. Infine il codice macchina viene eseguito, molto rapidamente.
+2. Successivamente convertono ("compilano") lo script nel linguaggio della macchina.
+3. Infine il "codice macchina" viene eseguito, molto rapidamente.
 
 Il motore applica ottimizzazioni ad ogni passo del processo. Anche durante l'esecuzione dello script già compilato, analizza il flusso dati e applica ottimizzazioni al codice macchina. Nonostante tutto l'esecuzione dello script risulta essere molto veloce.
 ```

--- a/1-js/01-getting-started/1-intro/article.md
+++ b/1-js/01-getting-started/1-intro/article.md
@@ -68,7 +68,7 @@ Esempi di queste restrizioni possono essere:
 
     I moderni browser gli consentono di lavorare con i file, sempre con un accesso limitato e comunque solo se il comando proviene da utente, come il "dropping" di un file nella finestra del browser, o con la selezione  tramite il tag `<input>`.
 
-    Ci sono anche funzionalità che consentono di interagire con la camera/microfono e altri dispositivi, ma in ogni caso richiedono il permesso esplicito dell'utente. Quindi una pagina con JavaScript abilitato non può attivare la web-cam di nascosto, osservare i nostri comportamenti e inviare  informazioni a terzi.
+    Ci sono anche funzionalità che consentono di interagire con la camera/microfono e altri dispositivi, ma in ogni caso richiedono il permesso esplicito dell'utente. Quindi una pagina con JavaScript abilitato non può attivare la web-cam di nascosto, osservare i nostri comportamenti e inviare  informazioni alla [CIA](https://it.wikipedia.org/wiki/Central_Intelligence_Agency).
 - Pagine o schede diverse generalmente non sono a conoscenza dell'esistenza delle altre. In certi casi, tuttavia, può capitare; ad esempio quando una finestra ne apre un'altra tramite JavaScript. Ma anche in questo caso, il codice JavaScript non può accedere all'altra pagina se non appartiene allo stesso sito (stesso dominio, protocollo o porta).
 
     Questa viene definita la  "Same Origin Policy" ("Politica di Appartenenza alla Stessa Origine"). Per poter aggirare questo limite, *entrambe le pagine* devono contenere uno speciale codice JavaScript che consente di gestire lo scambio di dati.
@@ -103,7 +103,7 @@ Questo è prevedibile, poiché i progetti e i requisiti sono diversi da persona 
 
 Recentemente, per questo motivo, sono nati molti nuovi linguaggi che vengono *convertiti* in JavaScript prima di essere eseguiti nel browser.
 
-Gli strumenti moderni rendono la conversione molto veloce e pulita, consentendo agli sviluppatori di programmare in un altro linguaggio e di auto-convertirlo *under the hood* ("sotto il cofano").
+Gli strumenti moderni rendono la conversione molto veloce e pulita, consentendo agli sviluppatori di programmare in un altro linguaggio e di auto-convertirlo *under the hood*.
 
 Esempi di alcuni linguaggi:
 
@@ -111,7 +111,7 @@ Esempi di alcuni linguaggi:
 - [TypeScript](http://www.typescriptlang.org/) si occupa di aggiungere la "tipizzazione", per semplificare lo sviluppo e supportare sistemi più complessi. E' stato sviluppato da Microsoft.
 - [Flow](http://flow.org/) anche'esso aggiunge la tipizzazione dei dati, ma in un modo differente. Sviluppato da Facebook.
 - [Dart](https://www.dartlang.org/) è un linguaggio autonomo che possiede il suo motore, che esegue in ambienti esterni al browser (come mobile apps). E' stato introdotto da Google come alternativa a JavaScript, ma attualmente i browser richiedono la conversione in JavaScript, proprio come i precedenti.
-- [Brython](https://brython.info/) è un *transpiler* (un "traduttore"), scritto in Python, che consente di scrivere applicazioni in quest'ultimo senza utilizzare JavaScript.
+- [Brython](https://brython.info/) è un *transpiler*, scritto in Python, che consente di scrivere applicazioni in quest'ultimo senza utilizzare JavaScript.
 - [Kotlin](https://kotlinlang.org/docs/reference/js-overview.html) è un moderno, conciso e sicuro linguaggio di programmazione mirato ai browsers o a Node.
 
 Ce ne sono molti altri. Ovviamente, per comprendere cosa stiamo facendo, se utilizziamo uno di questi linguaggi dovremmo altresì conoscere JavaScript.

--- a/1-js/01-getting-started/1-intro/article.md
+++ b/1-js/01-getting-started/1-intro/article.md
@@ -15,7 +15,7 @@ Sotto questo aspetto, JavaScript è molto differente da un altro linguaggio chia
 ```smart header="Perché si chiama <u>Java</u>Script?"
 In origine JavaScript aveva un altro nome: "LiveScript". In quel periodo Java era molto popolare, per questo si è pensato che identificare Javascript come il "fratello minore" di Java potesse aiutare alla sua diffusione.
 
-Evolvendosi, JavaScript è diventato un linguaggio completamente indipendente, con una specifica personale chiamata [ECMAScript](http://en.wikipedia.org/wiki/ECMAScript), e adesso non ha quasi nulla in comune con Java.
+Evolvendosi, JavaScript è diventato un linguaggio completamente indipendente, le cui specifiche sono definite da [ECMAScript](http://en.wikipedia.org/wiki/ECMAScript), e adesso non ha quasi nulla in comune con Java.
 ```
 
 Attualmente, JavaScript può essere eseguito non solo nei browser, ma anche nei server web e in altri ambienti che supportano il [motore JavaScript](https://en.wikipedia.org/wiki/JavaScript_engine) (JavaScript engine).
@@ -39,46 +39,46 @@ Il funzionamento di questi motori è complicato, ma i concetti alla base sono se
 2. Successivamente convertono ("compilano") lo script nel linguaggio della macchina.
 3. Infine il "codice macchina" viene eseguito, molto rapidamente.
 
-Il motore applica ottimizzazioni ad ogni passo del processo. Anche durante l'esecuzione dello script già compilato, analizza il flusso dati e applica ottimizzazioni al codice macchina. Nonostante tutto l'esecuzione dello script risulta essere molto veloce.
+Il motore ottimizza il codice ad ogni passaggio del processo, anche durante l'esecuzione dello script già compilato, quando ne analizza il flusso dati. Nonostante tutto l'esecuzione dello script risulta essere molto veloce.
 ```
 
 ## Cosa può fare JavaScript a livello browser?
 
-JavaScript al giorno d'oggi è un linguaggio di programmazione "sicuro". Non consente alcun accesso di basso livello alla memoria o alla CPU, questo perché è stato creato con lo scopo di funzionare nei browser, che non richiedono questo tipo di privilegi.
+JavaScript, al giorno d'oggi, è un linguaggio di programmazione "sicuro". Non consente alcun accesso di basso livello alla memoria o alla CPU. Questo perché è stato creato con lo scopo di funzionare nei browser, che non richiedono questi tipi di privilegi.
 
 Le capacità di JavaScript dipendono molto dall'ambiente in cui lo si esegue. Ad esempio, [Node.js](https://wikipedia.org/wiki/Node.js) supporta funzioni che consentono a JavaScript di scrivere/leggere file, eseguire richieste web, etc.
 
-JavaScript integrato nel browser può fare qualsiasi cosa legata alla manipolazione della pagina, interagire con l'utente e con il server.
+Integrato nel browser Javascript può fare qualsiasi cosa legata alla manipolazione della pagina, all'interazione con l'utente e con il server.
 
 Ad esempio, è possibile:
 
 - Aggiungere HTML alla pagina, cambiare il contenuto esistente, modificare lo stile.
 - Reagire alle azioni dell'utente, click del mouse, movimenti del cursore, input da tastiera.
 - Inviare richieste al server tramite la rete, caricare e scaricare file (con l'ausilio di[AJAX](https://en.wikipedia.org/wiki/Ajax_(programming)) e [COMET](https://en.wikipedia.org/wiki/Comet_(programming))).
-- Prelevare e impostare cookies, interrogare l'utente e mostrare messaggi.
+- Prelevare e impostare cookies, interrogare l'utente, mostrare messaggi.
 - Memorizzare i dati client-side ("memorizzazione locale").
 
 ## Cosa NON può fare JavaScript a livello browser?
 
-Le possibilità di JavaScript nel browser sono limitate per la sicurezza dell'utente. L'intento è di prevenire che una pagina "maligna" tenti di accedere alle informazioni personali o di danneggiare i dati degli utenti.
+Per la sicurezza dell'utente, le possibilità di JavaScript nel browser sono limitate. L'intento è di prevenire che una pagina "maligna" tenti di accedere alle informazioni personali o di danneggiare i dati degli utenti.
 
-Degli esempi di queste restrizioni possono essere:
+Esempi di queste restrizioni possono essere:
 
-- JavaScript in una pagina web non può leggere o scrivere in qualsiasi file nell'hard disk, ne copiare o eseguire programmi. Non ha accesso diretto alle funzioni di sistema operativo.
+- JavaScript, in una pagina web, non può leggere o scrivere in qualsiasi file nell'hard disk, né copiare o eseguire programmi. Non ha accesso diretto alle funzioni del sistema operativo.
 
     I moderni browser gli consentono di lavorare con i file, sempre con un accesso limitato e comunque solo se il comando proviene da utente, come il "dropping" di un file nella finestra del browser, o con la selezione  tramite il tag `<input>`.
 
-    Ci sono anche funzionalità che consentono di interagire con la camera/microfono e altri dispositivi, ma in ogni caso richiedono il permesso esplicito dell'utente. Quindi una pagina con JavaScript abilitato non può attivare la web-cam di nascosto, osservare i nostri comportamenti e inviare le informazioni all' [NSA](https://en.wikipedia.org/wiki/National_Security_Agency).
-- Pagine o schede diverse generalmente non sono a conoscenza dell'esistenza delle altre. In certi casi può però capitare, ad esempio che una finestra ne apra un'altra tramite JavaScript. Ma anche in questo caso, il codice JavaScript non può accedere all'altra pagina se non appartiene allo stesso sito (stesso dominio, protocollo o porta).
+    Ci sono anche funzionalità che consentono di interagire con la camera/microfono e altri dispositivi, ma in ogni caso richiedono il permesso esplicito dell'utente. Quindi una pagina con JavaScript abilitato non può attivare la web-cam di nascosto, osservare i nostri comportamenti e inviare  informazioni a terzi.
+- Pagine o schede diverse generalmente non sono a conoscenza dell'esistenza delle altre. In certi casi, tuttavia, può capitare; ad esempio quando una finestra ne apre un'altra tramite JavaScript. Ma anche in questo caso, il codice JavaScript non può accedere all'altra pagina se non appartiene allo stesso sito (stesso dominio, protocollo o porta).
 
     Questa viene definita la  "Same Origin Policy" ("Politica di Appartenenza alla Stessa Origine"). Per poter aggirare questo limite, *entrambe le pagine* devono contenere uno speciale codice JavaScript che consente di gestire lo scambio di dati.
 
-    Questa limitazione è sempre dovuta alla sicurezza dell'utente. Una pagina proveniente da `http://anysite.com` che è stata aperta da un utente, non deve essere in grado di accedere ad un'altra scheda del browser con l'URL `http://gmail.com` (per esempio) e rubare le informazioni.
-- JavaScript può facilmente comunicare con il server da cui la pagina proviene. Ma la sua abilità di ricevere dati da altri siti/domini è limitata. Sebbene sia possibile, effettuare delle richieste esplicite (passate tramite HTTP headers) dall'indirizzo remoto. Ancora una volta, queste sono limitazioni dovute alla sicurezza.
+    Questa limitazione è sempre dovuta alla sicurezza dell'utente. Una pagina proveniente da `http://anysite.com` che è stata aperta da un utente, ad esempio, non deve essere in grado di accedere ad un'altra scheda del browser con l'URL `http://gmail.com`  e rubarne le informazioni.
+- JavaScript può facilmente comunicare con il server da cui la pagina proviene. Ma la sua abilità di ricevere dati da altri siti/domini è limitata. Sebbene sia possibile, sono richieste esplicite autorizzazioni (passate tramite HTTP headers) dall'indirizzo remoto. Ancora una volta, una limitazione dovuta alla sicurezza.
 
 ![](limitations.svg)
 
-Queste limitazioni non esistono se JavaScript viene eseguito fuori dal browser, ad esempio in un server. I browser moderni permettono l'installazione di plugin ed estensioni che consentono di aumentare i permessi.
+Queste limitazioni non si pongono se JavaScript viene eseguito fuori dal browser, ad esempio in un server. I browser moderni permettono l'installazione di plugin ed estensioni che consentono di estendere vari permessi.
 
 ## Cosa rende JavaScript unico?
 
@@ -87,7 +87,7 @@ Ci sono almeno *tre* cose che rendono JavaScript cosi unico:
 ```compare
 + Completa integrazione con HTML/CSS.
 + Operazioni semplici vengono eseguite semplicemente.
-+ Supportato dai maggiori browser ed è attivo di default.
++ Supportato dai maggiori browser ed integrato di default.
 ```
 JavaScript è l'unica tecnologia in ambiente browser che combina queste tre caratteristiche.
 
@@ -99,25 +99,25 @@ Quando si ha in programma di imparare una nuova tecnologia, è fondamentale veri
 
 La sintassi di JavaScript non soddisfa le necessità di tutti. Alcune persone necessitano di caratteristiche differenti.
 
-Questo è prevedibile, poiché i progetti e i requisiti sono diversi di persona in persona.
+Questo è prevedibile, poiché i progetti e i requisiti sono diversi da persona a persona.
 
-Recentemente, per questo motivo, sono nati molti nuovi linguaggi che vengono *convertiti* in JavaScript, prima di essere eseguiti nel browser.
+Recentemente, per questo motivo, sono nati molti nuovi linguaggi che vengono *convertiti* in JavaScript prima di essere eseguiti nel browser.
 
-Gli strumenti moderni rendono la conversione molto veloce e pulita, consentendo agli sviluppatori di programmare in un altro linguaggio e di auto-convertirlo "sotto il cofano".
+Gli strumenti moderni rendono la conversione molto veloce e pulita, consentendo agli sviluppatori di programmare in un altro linguaggio e di auto-convertirlo *under the hood* ("sotto il cofano").
 
 Esempi di alcuni linguaggi:
 
 - [CoffeeScript](http://coffeescript.org/) è un linguaggio che introduce una sintassi semplificata che consente di scrivere codice più leggibile. Amato dagli sviluppatori provenienti da Ruby.
 - [TypeScript](http://www.typescriptlang.org/) si occupa di aggiungere la "tipizzazione", per semplificare lo sviluppo e supportare sistemi più complessi. E' stato sviluppato da Microsoft.
 - [Flow](http://flow.org/) anche'esso aggiunge la tipizzazione dei dati, ma in un modo differente. Sviluppato da Facebook.
-- [Dart](https://www.dartlang.org/) è un linguaggio autonomo che possiede il suo motore che esegue in ambienti esterni al browser (come mobile apps). E' stato introdotto da Google come alternativa a JavaScript, ma attualmente, i browser richiedono la conversione in JavaScript, proprio come i precedenti.
-- [Brython](https://brython.info/) è un traduttore, che codice scritto in Python in codice JavaScript, consente quindi di scrivere applicazioni in Python senza utilizzare JavaScript.
+- [Dart](https://www.dartlang.org/) è un linguaggio autonomo che possiede il suo motore, che esegue in ambienti esterni al browser (come mobile apps). E' stato introdotto da Google come alternativa a JavaScript, ma attualmente i browser richiedono la conversione in JavaScript, proprio come i precedenti.
+- [Brython](https://brython.info/) è un *transpiler* (un "traduttore"), scritto in Python, che consente di scrivere applicazioni in quest'ultimo senza utilizzare JavaScript.
 - [Kotlin](https://kotlinlang.org/docs/reference/js-overview.html) è un moderno, conciso e sicuro linguaggio di programmazione mirato ai browsers o a Node.
 
-Ce ne sono molti altri. Ovviamente se utilizziamo uno di questi linguaggi, dovremmo almeno conoscere JavaScript, per comprendere cosa stiamo facendo.
+Ce ne sono molti altri. Ovviamente, per comprendere cosa stiamo facendo, se utilizziamo uno di questi linguaggi dovremmo altresì conoscere JavaScript.
 
 ## Riepilogo
 
-- JavaScript è stato creato come linguaggio unico per i browser, ma attualmente viene utilizzato con efficacia in molti altri ambienti.
-- Attualmente JavaScript si trova in una posizione unica come linguaggio più diffuso per lo sviluppo web, grazie ad una completa integrazione con HTML/CSS.
-- Ci sono molti linguaggio che possono essere "convertiti" in JavaScript che risolvono certe esigenze. E' fortemente consigliato di leggere brevemente le funzionalità di alcuni di essi, però solo dopo essersi focalizzati su JavaScript.
+- JavaScript è stato creato specificamente per i browser, ma attualmente viene utilizzato con efficacia in molti altri ambienti.
+- Attualmente, per quanto riguarda lo sviluppo del web, JavaScript si trova in una posizione unica grazie ad una completa integrazione con HTML/CSS.
+- Ci sono molti linguaggi che possono essere "convertiti" in JavaScript; essi provvedono le stesse funzionalità e risolvono gli stessi problemi. E' fortemente consigliato di leggere brevemente le funzionalità di alcuni di essi, dopo avert studiato e compreso JavaScript.


### PR DESCRIPTION
Salve a tutti, spero che queste piccole modifiche possano essere utili in qualche modo. Mi sono fermato alla primissima parte dell'articolo, in modo da avere un feedback. 
Le ragioni di queste modifiche: 

1) Si dice 'sotto' questo aspetto; 'in' non è corretto.
2) Il soggetto della frase è *Java*; subito dopo si specifica 'questo linguaggio': è come ripetere Java! Ho cambiato con un semplice *Javascript*: la frase ora è più breve ed intuitiva. Ho altresì cambiato 'nella' con 'alla' (vi è una differenza molto sottile, ma 'palpabile'; la seconda è leggermente più astratta, si presta a più contesti; questa modifica, tuttavia, è forse assai soggettiva). 
3) La specifica (anche in inglese, *specification*) è al singolare, mentre nella frase attuale ci riferiamo ad essa come se fosse al plurale. Ora, se si vuol tenere *specifiche* (in italiano sarebbe più intuitivo, forse) bisognerebbe cambiare la frase in qualcosa come *delle specifiche personali **definite** nella [ECMAScript]*.
4) La versione inglese specifica 'sometimes', riferendosi ai vari nomi che seguono. 
5) 'in linguaggio macchina' è una traduzione 'alla lettera' di 'to the machine code';  in questo contesto non ha lo stesso significato di una frase come 'tradurre in inglese'. Il 'linguaggio macchina' è figurativo. E' più corretto dire 'nel linguaggio della macchina' (per meglio spiegarmi con un'analogia: pensate alla differenza tra 'in linguaggio aborigeno' e 'nel linguaggio aborigeno'; o 'in linguaggio commerciale' e 'nel linguaggio commerciale').
6) 'codice macchina' tra virgolette, per far capire che è figurativo (vedi sopra).