### PR TITLE
correzione di "esemepio"

### DIFF
--- a/1-js/05-data-types/03-string/article.md
+++ b/1-js/05-data-types/03-string/article.md
@@ -185,7 +185,7 @@ alert( str[0] ); // non funziona
 
 Il metodo utilizzato per aggirare questo problema è creare una nuova stringa ed assegnarla a `str` sostituendo quella vecchia.
 
-Ad esemepio:
+Ad esempio:
 
 ```js run
 let str = 'Hi';


### PR DESCRIPTION
correzione di "esemepio" nella corretta forma "esempio"